### PR TITLE
Add SnapshottingDefaults

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -155,6 +155,7 @@ public func assertSnapshots<Value, Format>(
 ///   - name: An optional description of the snapshot.
 ///   - recording: Whether or not to record a new reference.
 ///   - snapshotDirectory: Optional directory to save snapshots. By default snapshots will be saved in a directory with the same name as the test file, and that directory will sit inside a directory `__Snapshots__` that sits next to your test file.
+///   - snapshotSubdirectory: The default subdirectory for snapshots in the same directory as the test file. Defaults to `__Snapshots__` that sits next to your test file. Only used when `snapshotDirectory` is nil.
 ///   - timeout: The amount of time a snapshot must be generated in.
 ///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
 ///   - testName: The name of the test in which failure occurred. Defaults to the function name of the test case in which this function was called.
@@ -165,8 +166,9 @@ public func verifySnapshot<Value, Format>(
   as snapshotting: Snapshotting<Value, Format>,
   named name: String? = nil,
   record recording: Bool = false,
-  snapshotDirectory: String? = nil,
-  timeout: TimeInterval = 5,
+  snapshotDirectory: String? = SnapshottingDefaults.snapshotDirectory,
+  snapshotSubdirectory: String = SnapshottingDefaults.snapshotSubdirectory,
+  timeout: TimeInterval = SnapshottingDefaults.timeout,
   file: StaticString = #file,
   testName: String = #function,
   line: UInt = #line
@@ -182,7 +184,7 @@ public func verifySnapshot<Value, Format>(
       let snapshotDirectoryUrl = snapshotDirectory.map { URL(fileURLWithPath: $0, isDirectory: true) }
         ?? fileUrl
           .deletingLastPathComponent()
-          .appendingPathComponent("__Snapshots__")
+          .appendingPathComponent(snapshotSubdirectory)
           .appendingPathComponent(fileName)
 
       let identifier: String

--- a/Sources/SnapshotTesting/Snapshotting/SnapshottingImageDefaults.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SnapshottingImageDefaults.swift
@@ -8,6 +8,15 @@
 import Foundation
 
 
+public enum SnapshottingDefaults {
+    /// The default subdirectory for snapshots in the same directory as the test file. Defaults to `__Snapshots__` that sits next to your test file. Only used when `snapshotDirectory` is nil.
+    public static var snapshotSubdirectory = "__Snapshots__"
+    /// Optional directory to save snapshots. By default snapshots will be saved in a directory with the same name as the test file, and that directory will sit inside a directory `__Snapshots__` that sits next to your test file.
+    public static var snapshotDirectory: String? = nil
+    /// The amount of time a snapshot must be generated in.
+    public static var timeout: TimeInterval = 5
+}
+
 /// Default properties for global image diffing default values
 public enum SnapshottingImageDefaults {
     /// The percentage of pixels that must match. Value between 0-1


### PR DESCRIPTION
Add some global defaults that can be configured including the option to change the default `__Snapshots__` directory name. This can be useful if someone wants to maintain two sets of snapshots for different build configurations.